### PR TITLE
Read protocol from nmconnection-file and pass it to command

### DIFF
--- a/nm_openconnect.py
+++ b/nm_openconnect.py
@@ -97,6 +97,7 @@ class Plugin(dbus.service.Object):
         self.gateway: Optional[str] = None
         self.password: Optional[str] = None
         self.username: Optional[str] = None
+        self.protocol: Optional[str] = None
         self.form_data: list[str] = []
 
     def run(self):
@@ -114,7 +115,7 @@ class Plugin(dbus.service.Object):
         cmd = [
             'openconnect', '-u', self.username, '--passwd-on-stdin',
             '--script', '/usr/lib/nm-openconnect-service-openconnect-helper',
-            '--syslog', '--protocol', 'anyconnect', *self.form_data,
+            '--syslog', '--protocol', self.protocol, *self.form_data,
             self.gateway
         ]
         logger.info('command to connect: %s', dumps(cmd, ensure_ascii=False))
@@ -147,6 +148,7 @@ class Plugin(dbus.service.Object):
         vpn = settings.get('vpn', {})
         data = vpn.get('data', {})
         self.username = data.get('username')
+        self.protocol = data.get('protocol')
         self.gateway = data.get('gateway')
 
         # Parse form data to command line terms.

--- a/nm_openconnect.py
+++ b/nm_openconnect.py
@@ -111,12 +111,19 @@ class Plugin(dbus.service.Object):
         connection = convert(connection)
         logger.info('nm-oc: Connect(%s)', connection)
 
+        # See original implementation for details.
+        #
+        # [1]: https://gitlab.gnome.org/GNOME/NetworkManager-openconnect/-/
+        #      blob/1.2.10/src/nm-openconnect-service.c?ref_type=tags#L496-504
+        protocol = ()
+        if self.protocol and self.protocol != 'anyconnect':
+            protocol = ('--protocol', protocol)
+
         env = {'NM_DBUS_SERVICE_OPENCONNECT': self.bus_name}  # Helper script.
         cmd = [
             'openconnect', '-u', self.username, '--passwd-on-stdin',
             '--script', '/usr/lib/nm-openconnect-service-openconnect-helper',
-            '--syslog', '--protocol', self.protocol, *self.form_data,
-            self.gateway
+            '--syslog', *protocol, *self.form_data, self.gateway
         ]
         logger.info('command to connect: %s', dumps(cmd, ensure_ascii=False))
         self.StateChanged(ServiceState.Starting)


### PR DESCRIPTION
This change allows the script to retrieve the protocol from the ".nmconnection" file and pass it to the openconnect command line